### PR TITLE
need to use 6.6 snapshot now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <cdi.version>4.1.0-M2</cdi.version>
         <servlet.version>6.0.0-M2</servlet.version>
         <sigtest.version>1.6</sigtest.version>
-        <hibernate.data.version>6.5.0-SNAPSHOT</hibernate.data.version>
+        <hibernate.data.version>6.6.0-SNAPSHOT</hibernate.data.version>
         <weld-junit.version>4.0.2.Final</weld-junit.version>
     </properties>
 


### PR DESCRIPTION
At some point in the last couple of days, HIbernate changed to producing `6.6.0-SNAPSHOT`s, so if we want my latest changes, that's where they are.