### PR TITLE
Revert "use 'create' instead of 'drop-and-create'"

### DIFF
--- a/runner/src/test/resources/META-INF/persistence.xml
+++ b/runner/src/test/resources/META-INF/persistence.xml
@@ -21,7 +21,7 @@
             <property name="jakarta.persistence.jdbc.password" value="" />
 
             <property name="jakarta.persistence.schema-generation.database.action"
-                      value="create"/>
+                      value="drop-and-create"/>
 
             <property name="hibernate.allow_update_outside_transaction" value="true"/>
 


### PR DESCRIPTION
This was temporary until the EMF scoping was fixed.

This reverts commit 7a0b204cf6c8f517553aca1d13ac0d522dc616fe.