### PR TITLE
add (passing) StandalonePersistenceEntityTests

### DIFF
--- a/runner/src/test/java/org/hibernate/ee/jakarta/data/tck/StandaloneEntityTests.java
+++ b/runner/src/test/java/org/hibernate/ee/jakarta/data/tck/StandaloneEntityTests.java
@@ -36,7 +36,7 @@ public class StandaloneEntityTests extends EntityTests {
                     DirectoryBuildCompatibleExtension.class)
             .activate(RequestScoped.class)
             .inject(this)
-            .setPersistenceUnitFactory((ip) -> appEMF)
+            .setPersistenceUnitFactory(ip -> appEMF)
             .build()
             ;
 

--- a/runner/src/test/java/org/hibernate/ee/jakarta/data/tck/StandalonePersistenceEntityTests.java
+++ b/runner/src/test/java/org/hibernate/ee/jakarta/data/tck/StandalonePersistenceEntityTests.java
@@ -1,0 +1,29 @@
+package org.hibernate.ee.jakarta.data.tck;
+
+import ee.jakarta.tck.data.core.cdi.provider.DirectoryBuildCompatibleExtension;
+import ee.jakarta.tck.data.standalone.persistence.Catalog_;
+import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(WeldJunit5Extension.class)
+public class StandalonePersistenceEntityTests extends PersistenceEntityTests {
+    @Inject
+    EntityManagerFactory appEMF;
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(PersistenceEntityTests.class,
+                    Catalog_.class,
+                    EntityManagerFactoryProducer.class,
+                    DirectoryBuildCompatibleExtension.class)
+            .activate(RequestScoped.class)
+            .inject(this)
+            .setPersistenceUnitFactory(ip -> appEMF)
+            .build()
+            ;
+}

--- a/runner/src/test/resources/META-INF/persistence.xml
+++ b/runner/src/test/resources/META-INF/persistence.xml
@@ -13,6 +13,7 @@
         <class>ee.jakarta.tck.data.standalone.entity.Box</class>
         <class>ee.jakarta.tck.data.standalone.entity.Coordinate</class>
         <class>ee.jakarta.tck.data.web.validation.Rectangle</class>
+        <class>ee.jakarta.tck.data.standalone.persistence.Product</class>
 
         <properties>
             <property name="jakarta.persistence.jdbc.url"


### PR DESCRIPTION
This shows that after fixes to both Hibernate and the TCK, we now pass the `PersistenceEntityTests`.