### PR TITLE
Fix web runner groups

### DIFF
--- a/runner-web/pom.xml
+++ b/runner-web/pom.xml
@@ -225,7 +225,7 @@
                     </dependenciesToScan>
                     <!-- Works around WFCORE-4211 -->
                     <argLine>${modular.jdk.args}</argLine>
-                    <groups>core,persistence</groups>
+                    <groups><![CDATA[core & persistence]]></groups>
                     <!-- If running back-to-back tests at different levels
                      use this to distinguish the results -->
                     <reportNameSuffix>core</reportNameSuffix>


### PR DESCRIPTION
The `<groups>` configuration for surefire/failsafe is a logical operation. 

`<groups>core,persistence</groups>` -> Execute any test with the `core` tag. Execute any test with the `persistence` tag.
`<groups><![CDATA[core & persistence]]></groups>` -> Execute any test with both the `core` and `persistence` tags.

In the original case you will execute Core+NoSQL tests and Web+Persistence tests when you did not intend to do so.

FYI @starksm64 